### PR TITLE
[refactor/use-extension-function] Refactor 'getImageSize' function

### DIFF
--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
@@ -60,11 +60,12 @@ internal object PeekabooImageResizer {
     private fun getImageSize(
         context: Context,
         uri: Uri,
-    ): Int = context.contentResolver.query(uri, null, null, null, null).use { cursor ->
-        val sizeIndex = cursor?.getColumnIndex(OpenableColumns.SIZE)
-        cursor?.moveToFirst()
-        sizeIndex?.let { cursor.getInt(it) } ?: 0
-    }
+    ): Int =
+        context.contentResolver.query(uri, null, null, null, null).use { cursor ->
+            val sizeIndex = cursor?.getColumnIndex(OpenableColumns.SIZE)
+            cursor?.moveToFirst()
+            sizeIndex?.let { cursor.getInt(it) } ?: 0
+        }
 
     private fun getOriginalImageByteArray(
         context: Context,

--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
@@ -60,13 +60,10 @@ internal object PeekabooImageResizer {
     private fun getImageSize(
         context: Context,
         uri: Uri,
-    ): Int {
-        val cursor = context.contentResolver.query(uri, null, null, null, null)
+    ): Int = context.contentResolver.query(uri, null, null, null, null).use { cursor ->
         val sizeIndex = cursor?.getColumnIndex(OpenableColumns.SIZE)
         cursor?.moveToFirst()
-        val size = sizeIndex?.let { cursor.getInt(it) } ?: 0
-        cursor?.close()
-        return size
+        sizeIndex?.let { cursor.getInt(it) } ?: 0
     }
 
     private fun getOriginalImageByteArray(
@@ -116,9 +113,10 @@ internal object PeekabooImageResizer {
                     options.inSampleSize = inSampleSize
 
                     context.contentResolver.openInputStream(uri)?.use { scaledInputStream ->
-                        BitmapFactory.decodeStream(scaledInputStream, null, options)?.also { bitmap ->
-                            PeekabooBitmapCache.instance.put(resizeCacheKey, bitmap)
-                        }
+                        BitmapFactory.decodeStream(scaledInputStream, null, options)
+                            ?.also { bitmap ->
+                                PeekabooBitmapCache.instance.put(resizeCacheKey, bitmap)
+                            }
                     }
                 }
             }
@@ -171,7 +169,11 @@ internal object PeekabooImageResizer {
                 colorFilter = ColorMatrixColorFilter(colorMatrix)
             }
 
-        return Bitmap.createBitmap(originalBitmap.width, originalBitmap.height, Bitmap.Config.ARGB_8888).also { bitmap ->
+        return Bitmap.createBitmap(
+            originalBitmap.width,
+            originalBitmap.height,
+            Bitmap.Config.ARGB_8888,
+        ).also { bitmap ->
             val canvas = Canvas(bitmap)
             canvas.drawBitmap(originalBitmap, 0f, 0f, paint)
         }
@@ -184,7 +186,8 @@ internal object PeekabooImageResizer {
     ): Bitmap {
         val inputStream = context.contentResolver.openInputStream(uri) ?: return bitmap
         val exif = ExifInterface(inputStream)
-        val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        val orientation =
+            exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
 
         val matrix = Matrix()
         when (orientation) {


### PR DESCRIPTION
- use 'use' extension function to release resource safe

```kotlin
@InlineOnly
public inline fun <T : Closeable?, R> T.use(block: (T) -> R): R {
    contract {
        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
    }
    var exception: Throwable? = null
    try {
        return block(this)
    } catch (e: Throwable) {
        exception = e
        throw e
    } finally {
        when {
            apiVersionIsAtLeast(1, 1, 0) -> this.closeFinally(exception)
            this == null -> {}
            exception == null -> close()
            else ->
                try {
                    close()
                } catch (closeException: Throwable) {
                    // cause.addSuppressed(closeException) // ignored here
                }
        }
    }
}
```