### PR TITLE
[fix/camera-capture-ios] Fix Capture Functionality Not Triggering in iOS

### DIFF
--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
@@ -41,6 +41,8 @@ actual class PeekabooCameraState(
     }
 
     actual fun capture() {
+        isCapturing = true
+        triggerCaptureAnchor?.invoke()
     }
 
     internal fun stopCapturing() {


### PR DESCRIPTION
## Changes
Implemented the missing logic in the `capture()` method to correctly set `isCapturing` to true and invoke the `triggerCaptureAnchor` in `PeekabooCameraState.ios.kt`
