### PR TITLE
Bump AGP 8.3.0, jetbrains compose to 1.6.0, compose ui to 1.6.1, compose foundation to 1.6.1, and compose material3 to 1.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary merge=union

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peekaboo
 [![Kotlin](https://img.shields.io/badge/kotlin-1.9.22-blue.svg?logo=kotlin)](http://kotlinlang.org)
-[![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-v1.5.12-blue)](https://github.com/JetBrains/compose-multiplatform)
+[![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-v1.6.0-blue)](https://github.com/JetBrains/compose-multiplatform)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.onseok/peekaboo-image-picker?color=orange)](https://search.maven.org/search?q=g:io.github.onseok)
 [![Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-agp = "8.2.2"
+agp = "8.3.0"
 kotlin = "1.9.22"
-compose = "1.5.12"
+compose = "1.6.0"
 compose-compiler = "1.5.8"
-compose-ui = "1.5.4"
-compose-foundation = "1.5.4"
-compose-material3 = "1.1.2"
+compose-ui = "1.6.1"
+compose-foundation = "1.6.1"
+compose-material3 = "1.2.0"
 androidx-activityCompose = "1.8.2"
 androidx-lifecycleViewmodelCompose = "2.7.0"
-androidx-version = "1.7.1"
+androidx-annotation = "1.7.1"
 nexus-publish = "2.0.0-rc-1"
 spotless = "6.25.0"
 ktlint = "1.0.1"
@@ -29,6 +29,10 @@ multiplatform-paging = "3.3.0-alpha02-0.4.0"
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycleViewmodelCompose" }
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-ui" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui" }
@@ -38,7 +42,6 @@ components-resources = { group = "org.jetbrains.compose.components", name = "com
 nexus-publish = { module = "io.github.gradle-nexus.publish-plugin:io.github.gradle-nexus.publish-plugin.gradle.plugin", version.ref = "nexus-publish" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
@@ -46,11 +49,8 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
 camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
-androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
-androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycleViewmodelCompose" }
 paging-common = { module = "app.cash.paging:paging-common", version.ref = "multiplatform-paging" }
 paging-compose-common = { module = "app.cash.paging:paging-compose-common", version.ref = "multiplatform-paging" }
-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-version" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/peekaboo-image-picker/build.gradle.kts
+++ b/peekaboo-image-picker/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material)
-            implementation(libs.annotation)
+            implementation(libs.androidx.annotation)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/sample/ios/peekaboo.xcodeproj/project.pbxproj
+++ b/sample/ios/peekaboo.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"peekaboo/Preview Content\"";
-				DEVELOPMENT_TEAM = 6XUD8CQBN9;
+				DEVELOPMENT_TEAM = 2T56TV4Z49;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -313,7 +313,7 @@
 					"-framework",
 					common,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.preat.peekaboo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onseok.peekaboo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -329,7 +329,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"peekaboo/Preview Content\"";
-				DEVELOPMENT_TEAM = 6XUD8CQBN9;
+				DEVELOPMENT_TEAM = 2T56TV4Z49;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -351,7 +351,7 @@
 					"-framework",
 					common,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.preat.peekaboo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.onseok.peekaboo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Changes
Bump AGP 8.3.0, jetbrains compose to 1.6.0, compose ui to 1.6.1, compose foundation to 1.6.1, and compose material3 to 1.2.0.