### PR TITLE
Fixing #71 - size of overlay containing capture and convert icons to match parent size

### DIFF
--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -26,6 +26,7 @@ import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -69,6 +70,7 @@ actual fun PeekabooCamera(
             modifier = modifier,
         )
         CompatOverlay(
+            modifier = Modifier.fillMaxSize(),
             state = state,
             captureIcon = captureIcon,
             convertIcon = convertIcon,
@@ -79,12 +81,13 @@ actual fun PeekabooCamera(
 
 @Composable
 private fun CompatOverlay(
+    modifier: Modifier,
     state: PeekabooCameraState,
     captureIcon: @Composable (onClick: () -> Unit) -> Unit,
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
 ) {
-    Box {
+    Box(modifier = modifier) {
         captureIcon(state::capture)
         convertIcon(state::toggleCamera)
         if (state.isCapturing) {


### PR DESCRIPTION
Fixing #71 - size of overlay containing capture and convert icons to match parent, so that modifier passed for the button is applied correctly (mainly for alignment of buttons)