### PR TITLE
[fix/exif-orientation-handling] Fix handling of Exif orientation info for image rotation/flipping

### DIFF
--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/PeekabooImageResizer.kt
@@ -201,6 +201,19 @@ internal object PeekabooImageResizer {
             ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
             ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
             ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.preScale(-1.0f, 1.0f)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+                matrix.preScale(1.0f, -1.0f)
+                matrix.postRotate(180f)
+            }
+            ExifInterface.ORIENTATION_TRANSPOSE -> {
+                matrix.preScale(-1.0f, 1.0f)
+                matrix.postRotate(270f)
+            }
+            ExifInterface.ORIENTATION_TRANSVERSE -> {
+                matrix.preScale(-1.0f, 1.0f)
+                matrix.postRotate(90f)
+            }
         }
 
         return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.android.kt
@@ -183,6 +183,19 @@ private fun rotateImageIfRequired(
         ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
         ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
         ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+        ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.preScale(-1.0f, 1.0f)
+        ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+            matrix.preScale(1.0f, -1.0f)
+            matrix.postRotate(180f)
+        }
+        ExifInterface.ORIENTATION_TRANSPOSE -> {
+            matrix.preScale(-1.0f, 1.0f)
+            matrix.postRotate(270f)
+        }
+        ExifInterface.ORIENTATION_TRANSVERSE -> {
+            matrix.preScale(-1.0f, 1.0f)
+            matrix.postRotate(90f)
+        }
     }
 
     return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)


### PR DESCRIPTION
## Changes
- Added handling for all Exif orientation flags in `PeekabooImageResizer`.
- Ensured that images are correctly rotated and flipped according to their Exif orientation info when being resized.
