### PR TITLE
Fix PeekabooCameraState recreation when lambda onCapture does not memoized

### DIFF
--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    private val onCapture: (ByteArray?) -> Unit,
+    internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
 
@@ -80,7 +80,8 @@ actual fun rememberPeekabooCameraState(
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        onCapture,
         saver = PeekabooCameraState.saver(onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onCapture) }
+    ) { PeekabooCameraState(initialCameraMode, onCapture) }.apply {
+        this.onCapture = onCapture
+    }
 }

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    private val onCapture: (ByteArray?) -> Unit,
+    internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
 
@@ -80,7 +80,8 @@ actual fun rememberPeekabooCameraState(
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        onCapture,
         saver = PeekabooCameraState.saver(onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onCapture) }
+    ) { PeekabooCameraState(initialCameraMode, onCapture) }.apply {
+        this.onCapture = onCapture
+    }
 }


### PR DESCRIPTION
When during recomposition onCapture lambda is recreating, PeekabooCameraState is recreating too. There is bug with state's isCapturing, isCameraReady, cameraMode is set to default values after creating new PeekabooCameraState. Now onCapture does not affect state recreating, it sets as new onCapture callback in PeekabooCameraState.

P.S. fix in 0.5.0 - remember onCapture lambda.