### PR TITLE
Fixed Issue with Applying Filters to Images Below Threshold Size on iOS

### DIFF
--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
@@ -163,7 +163,7 @@ private fun UIImage.fitInto(
 
         return applyFilterToUIImage(resizedImage, filterOptions)
     } else {
-        return this
+        return applyFilterToUIImage(this, filterOptions)
     }
 }
 


### PR DESCRIPTION
## Changes
- Fixed an issue where images below the resize threshold did not have filters applied in iOS