### PR TITLE
[feature/update-license-header-year] Update year of license header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/convention-plugins/src/main/kotlin/module.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/module.publication.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-image-picker/build.gradle.kts
+++ b/peekaboo-image-picker/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.android.kt
+++ b/peekaboo-image-picker/src/androidMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
+++ b/peekaboo-image-picker/src/commonMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
+++ b/peekaboo-image-picker/src/iosMain/kotlin/com/preat/peekaboo/image/picker/ImagePickerLauncher.ios.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/build.gradle.kts
+++ b/peekaboo-ui/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/model/PeekabooMediaImage.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/model/PeekabooMediaImage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/repository/PeekabooGalleryRepository.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/repository/PeekabooGalleryRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/viewmodel/PeekabooGalleryViewModel.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/viewmodel/PeekabooGalleryViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/viewmodel/PeekabooGalleryViewModelFactory.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/gallery/viewmodel/PeekabooGalleryViewModelFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/CameraMode.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/CameraMode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/gallery/ExperimentalPeekabooGalleryApi.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/gallery/ExperimentalPeekabooGalleryApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/CameraAccess.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/CameraAccess.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/gallery/PeekabooGallery.ios.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/CircularButton.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/CircularButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/InstagramCameraButton.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/InstagramCameraButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 onseok
+ * Copyright 2023-2024 onseok
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Spotless updates the year at the head of your license based on the year of your last commit.

```bash
./gradlew spotlessApply -PspotlessSetLicenseHeaderYearsFromGitHistory=true
```

I used this script.