### PR TITLE
[update/deps] Bump agp to 8.3.2, jetbrains compose to 1.6.2, nexus-publish to 2.0.0, gradle to 8.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "8.3.1"
+agp = "8.3.2"
 kotlin = "1.9.23"
 kotlinx-coroutines = "1.8.0"
-compose = "1.6.1"
+compose = "1.6.2"
 compose-compiler = "1.5.11"
 compose-ui = "1.6.4"
 compose-foundation = "1.6.4"
@@ -10,7 +10,7 @@ compose-material3 = "1.2.1"
 androidx-activityCompose = "1.8.2"
 androidx-lifecycleViewmodelCompose = "2.7.0"
 androidx-annotation = "1.7.1"
-nexus-publish = "2.0.0-rc-2"
+nexus-publish = "2.0.0"
 spotless = "6.25.0"
 ktlint = "1.0.1"
 
@@ -25,7 +25,7 @@ material = "1.11.0"
 accompanist = "0.34.0"
 camerax = "1.3.2"
 exifinterface = "1.3.7"
-multiplatform-paging = "3.3.0-alpha02-0.4.0"
+multiplatform-paging = "3.3.0-alpha02-0.5.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Changes
Bump agp to 8.3.2, jetbrains compose to 1.6.2, nexus-publish to 2.0.0, gradle to 8.7