### PR TITLE
Feature: Add 'onFrame' lambda to capture the current frame of the camera

### DIFF
--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -17,7 +17,6 @@ package com.preat.peekaboo.ui.camera
 
 import android.graphics.Bitmap
 import android.graphics.Matrix
-import android.os.SystemClock
 import androidx.camera.core.AspectRatio
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
@@ -151,7 +150,7 @@ private fun CameraWithGrantedPermission(
 
             analyzer.apply {
                 setAnalyzer(backgroundExecutor) { imageProxy ->
-                    val frameTime = SystemClock.uptimeMillis()
+                    val frameTime = System.currentTimeMillis()
                     val imageBytes = imageProxy.toByteArray()
                     onFrame(frameTime, imageBytes)
                 }

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -58,11 +58,12 @@ actual fun PeekabooCamera(
     onFrame: ((frame: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
-    val state = rememberPeekabooCameraState(
-        initialCameraMode = cameraMode,
-        onFrame = onFrame,
-        onCapture = onCapture,
-    )
+    val state =
+        rememberPeekabooCameraState(
+            initialCameraMode = cameraMode,
+            onFrame = onFrame,
+            onCapture = onCapture,
+        )
     Box(
         modifier = modifier,
     ) {
@@ -140,22 +141,24 @@ private fun CameraWithGrantedPermission(
     val previewView = remember { PreviewView(context) }
     val imageCapture: ImageCapture = remember { ImageCapture.Builder().build() }
     val backgroundExecutor = remember { Executors.newSingleThreadExecutor() }
-    val imageAnalyzer = remember(state.onFrame) {
-        state.onFrame?.let { onFrame ->
-            val analyzer = ImageAnalysis.Builder()
-                .setTargetAspectRatio(AspectRatio.RATIO_4_3)
-                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-                .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
-                .build()
+    val imageAnalyzer =
+        remember(state.onFrame) {
+            state.onFrame?.let { onFrame ->
+                val analyzer =
+                    ImageAnalysis.Builder()
+                        .setTargetAspectRatio(AspectRatio.RATIO_4_3)
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
+                        .build()
 
-            analyzer.apply {
-                setAnalyzer(backgroundExecutor) { imageProxy ->
-                    val imageBytes = imageProxy.toByteArray()
-                    onFrame(imageBytes)
+                analyzer.apply {
+                    setAnalyzer(backgroundExecutor) { imageProxy ->
+                        val imageBytes = imageProxy.toByteArray()
+                        onFrame(imageBytes)
+                    }
                 }
             }
         }
-    }
 
     val cameraSelector =
         remember(state.cameraMode) {

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -56,12 +56,12 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
-    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
     val state = rememberPeekabooCameraState(
         initialCameraMode = cameraMode,
-        onAnalyze = onAnalyze,
+        onFrame = onFrame,
         onCapture = onCapture,
     )
     Box(
@@ -141,8 +141,8 @@ private fun CameraWithGrantedPermission(
     val previewView = remember { PreviewView(context) }
     val imageCapture: ImageCapture = remember { ImageCapture.Builder().build() }
     val backgroundExecutor = remember { Executors.newSingleThreadExecutor() }
-    val imageAnalyzer = remember(state.onAnalyze) {
-        state.onAnalyze?.let { onAnalyze ->
+    val imageAnalyzer = remember(state.onFrame) {
+        state.onFrame?.let { onFrame ->
             val analyzer = ImageAnalysis.Builder()
                 .setTargetAspectRatio(AspectRatio.RATIO_4_3)
                 .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
@@ -153,7 +153,7 @@ private fun CameraWithGrantedPermission(
                 setAnalyzer(backgroundExecutor) { imageProxy ->
                     val frameTime = SystemClock.uptimeMillis()
                     val imageBytes = imageProxy.toByteArray()
-                    onAnalyze(frameTime, imageBytes)
+                    onFrame(frameTime, imageBytes)
                 }
             }
         }

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.android.kt
@@ -55,7 +55,7 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
-    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frame: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
     val state = rememberPeekabooCameraState(
@@ -150,9 +150,8 @@ private fun CameraWithGrantedPermission(
 
             analyzer.apply {
                 setAnalyzer(backgroundExecutor) { imageProxy ->
-                    val frameTime = System.currentTimeMillis()
                     val imageBytes = imageProxy.toByteArray()
-                    onFrame(frameTime, imageBytes)
+                    onFrame(imageBytes)
                 }
             }
         }

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    internal var onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    internal var onFrame: ((frame: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -60,7 +60,7 @@ actual class PeekabooCameraState(
 
     companion object {
         fun saver(
-            onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onFrame: ((frame: ByteArray) -> Unit)?,
             onCapture: (ByteArray?) -> Unit,
         ): Saver<PeekabooCameraState, Int> {
             return Saver(
@@ -82,7 +82,7 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
-    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frame: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    internal var onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    internal var onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -60,7 +60,7 @@ actual class PeekabooCameraState(
 
     companion object {
         fun saver(
-            onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
             onCapture: (ByteArray?) -> Unit,
         ): Saver<PeekabooCameraState, Int> {
             return Saver(
@@ -70,7 +70,7 @@ actual class PeekabooCameraState(
                 restore = {
                     PeekabooCameraState(
                         cameraMode = cameraModeFromId(it),
-                        onAnalyze = onAnalyze,
+                        onFrame = onFrame,
                         onCapture = onCapture,
                     )
                 },
@@ -82,12 +82,12 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
-    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        saver = PeekabooCameraState.saver(onAnalyze, onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onAnalyze, onCapture) }.apply {
+        saver = PeekabooCameraState.saver(onFrame, onCapture),
+    ) { PeekabooCameraState(initialCameraMode, onFrame, onCapture) }.apply {
         this.onCapture = onCapture
     }
 }

--- a/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
+++ b/peekaboo-ui/src/androidMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.android.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
+    internal var onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -58,7 +59,10 @@ actual class PeekabooCameraState(
     }
 
     companion object {
-        fun saver(onCapture: (ByteArray?) -> Unit): Saver<PeekabooCameraState, Int> {
+        fun saver(
+            onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onCapture: (ByteArray?) -> Unit,
+        ): Saver<PeekabooCameraState, Int> {
             return Saver(
                 save = {
                     it.cameraMode.id()
@@ -66,6 +70,7 @@ actual class PeekabooCameraState(
                 restore = {
                     PeekabooCameraState(
                         cameraMode = cameraModeFromId(it),
+                        onAnalyze = onAnalyze,
                         onCapture = onCapture,
                     )
                 },
@@ -77,11 +82,12 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
+    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        saver = PeekabooCameraState.saver(onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onCapture) }.apply {
+        saver = PeekabooCameraState.saver(onAnalyze, onCapture),
+    ) { PeekabooCameraState(initialCameraMode, onAnalyze, onCapture) }.apply {
         this.onCapture = onCapture
     }
 }

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
@@ -45,7 +45,7 @@ expect fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit = {},
     progressIndicator: @Composable () -> Unit = {},
     onCapture: (byteArray: ByteArray?) -> Unit,
-    onAnalyze: ((frameTime: Long, data: ByteArray) -> Unit)? = null,
+    onFrame: ((frameTime: Long, data: ByteArray) -> Unit)? = null,
     permissionDeniedContent: @Composable () -> Unit = {},
 )
 

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
@@ -45,6 +45,7 @@ expect fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit = {},
     progressIndicator: @Composable () -> Unit = {},
     onCapture: (byteArray: ByteArray?) -> Unit,
+    onAnalyze: ((frameTime: Long, data: ByteArray) -> Unit)? = null,
     permissionDeniedContent: @Composable () -> Unit = {},
 )
 

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.kt
@@ -45,7 +45,7 @@ expect fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit = {},
     progressIndicator: @Composable () -> Unit = {},
     onCapture: (byteArray: ByteArray?) -> Unit,
-    onFrame: ((frameTime: Long, data: ByteArray) -> Unit)? = null,
+    onFrame: ((frame: ByteArray) -> Unit)? = null,
     permissionDeniedContent: @Composable () -> Unit = {},
 )
 

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.remember
 @Composable
 expect fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode = CameraMode.Back,
-    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)? = null,
+    onFrame: ((frame: ByteArray) -> Unit)? = null,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState
 

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 @Composable
 expect fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode = CameraMode.Back,
+    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)? = null,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState
 

--- a/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
+++ b/peekaboo-ui/src/commonMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.remember
 @Composable
 expect fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode = CameraMode.Back,
-    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)? = null,
+    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)? = null,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState
 

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
@@ -173,9 +173,14 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
+    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
-    val state = rememberPeekabooCameraState(cameraMode, onCapture = onCapture)
+    val state = rememberPeekabooCameraState(
+        initialCameraMode = cameraMode,
+        onAnalyze = onAnalyze,
+        onCapture = onCapture,
+    )
     Box(
         modifier = modifier,
     ) {

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
@@ -189,7 +189,7 @@ actual fun PeekabooCamera(
     convertIcon: @Composable (onClick: () -> Unit) -> Unit,
     progressIndicator: @Composable () -> Unit,
     onCapture: (byteArray: ByteArray?) -> Unit,
-    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frame: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
     val state = rememberPeekabooCameraState(
@@ -722,7 +722,7 @@ class OrientationListener(
 }
 
 class CameraFrameAnalyzerDelegate(
-    private val onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    private val onFrame: ((frame: ByteArray) -> Unit)?,
 ) : NSObject(), AVCaptureVideoDataOutputSampleBufferDelegateProtocol {
     @OptIn(ExperimentalForeignApi::class)
     override fun captureOutput(
@@ -734,8 +734,6 @@ class CameraFrameAnalyzerDelegate(
         if (onFrame == null) return
 
         val imageBuffer = CMSampleBufferGetImageBuffer(didOutputSampleBuffer) ?: return
-        val frameTimeMs = (NSDate().timeIntervalSince1970 * 1000).toLong()
-
         CVPixelBufferLockBaseAddress(imageBuffer, 0uL)
         val baseAddress = CVPixelBufferGetBaseAddress(imageBuffer)
         val bufferSize = CVPixelBufferGetDataSize(imageBuffer)
@@ -743,7 +741,7 @@ class CameraFrameAnalyzerDelegate(
         CVPixelBufferUnlockBaseAddress(imageBuffer, 0uL)
 
         val bytes = data.toByteArray()
-        onFrame.invoke(frameTimeMs, bytes)
+        onFrame.invoke(bytes)
     }
 }
 

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCamera.ios.kt
@@ -88,13 +88,11 @@ import platform.CoreVideo.CVPixelBufferLockBaseAddress
 import platform.CoreVideo.CVPixelBufferUnlockBaseAddress
 import platform.CoreVideo.kCVPixelBufferPixelFormatTypeKey
 import platform.Foundation.NSData
-import platform.Foundation.NSDate
 import platform.Foundation.NSError
 import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.Foundation.dataWithBytes
-import platform.Foundation.timeIntervalSince1970
 import platform.QuartzCore.CATransaction
 import platform.QuartzCore.kCATransactionDisableActions
 import platform.UIKit.UIDevice
@@ -192,11 +190,12 @@ actual fun PeekabooCamera(
     onFrame: ((frame: ByteArray) -> Unit)?,
     permissionDeniedContent: @Composable () -> Unit,
 ) {
-    val state = rememberPeekabooCameraState(
-        initialCameraMode = cameraMode,
-        onFrame = onFrame,
-        onCapture = onCapture,
-    )
+    val state =
+        rememberPeekabooCameraState(
+            initialCameraMode = cameraMode,
+            onFrame = onFrame,
+            onCapture = onCapture,
+        )
     Box(
         modifier = modifier,
     ) {
@@ -541,18 +540,20 @@ private fun RealDeviceCamera(
     camera: AVCaptureDevice,
     modifier: Modifier,
 ) {
-    val queue = remember {
-        dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0UL)
-    }
+    val queue =
+        remember {
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0UL)
+        }
     val capturePhotoOutput = remember { AVCapturePhotoOutput() }
     val videoOutput = remember { AVCaptureVideoDataOutput() }
 
     val photoCaptureDelegate =
         remember(state) { PhotoCaptureDelegate(state::stopCapturing, state::onCapture) }
 
-    val frameAnalyzerDelegate = remember {
-        CameraFrameAnalyzerDelegate(state.onFrame)
-    }
+    val frameAnalyzerDelegate =
+        remember {
+            CameraFrameAnalyzerDelegate(state.onFrame)
+        }
 
     val triggerCapture: () -> Unit = {
         val photoSettings =
@@ -588,9 +589,10 @@ private fun RealDeviceCamera(
                     val captureQueue = dispatch_queue_create("sampleBufferQueue", attr = null)
                     videoOutput.setSampleBufferDelegate(frameAnalyzerDelegate, captureQueue)
                     videoOutput.alwaysDiscardsLateVideoFrames = true
-                    videoOutput.videoSettings = mapOf(
-                        kCVPixelBufferPixelFormatTypeKey to kCMPixelFormat_32BGRA,
-                    )
+                    videoOutput.videoSettings =
+                        mapOf(
+                            kCVPixelBufferPixelFormatTypeKey to kCMPixelFormat_32BGRA,
+                        )
                     captureSession.addOutput(videoOutput)
                 }
             }

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    internal var onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    internal var onFrame: ((frame: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -60,7 +60,7 @@ actual class PeekabooCameraState(
 
     companion object {
         fun saver(
-            onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onFrame: ((frame: ByteArray) -> Unit)?,
             onCapture: (ByteArray?) -> Unit,
         ): Saver<PeekabooCameraState, Int> {
             return Saver(
@@ -82,7 +82,7 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
-    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frame: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
-    internal var onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    internal var onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -60,7 +60,7 @@ actual class PeekabooCameraState(
 
     companion object {
         fun saver(
-            onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
             onCapture: (ByteArray?) -> Unit,
         ): Saver<PeekabooCameraState, Int> {
             return Saver(
@@ -70,7 +70,7 @@ actual class PeekabooCameraState(
                 restore = {
                     PeekabooCameraState(
                         cameraMode = cameraModeFromId(it),
-                        onAnalyze = onAnalyze,
+                        onFrame = onFrame,
                         onCapture = onCapture,
                     )
                 },
@@ -82,13 +82,13 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
-    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+    onFrame: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        saver = PeekabooCameraState.saver(onAnalyze, onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onAnalyze, onCapture) }.apply {
-        this.onAnalyze = onAnalyze
+        saver = PeekabooCameraState.saver(onFrame, onCapture),
+    ) { PeekabooCameraState(initialCameraMode, onFrame, onCapture) }.apply {
+        this.onFrame = onFrame
         this.onCapture = onCapture
     }
 }

--- a/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
+++ b/peekaboo-ui/src/iosMain/kotlin/com/preat/peekaboo/ui/camera/PeekabooCameraState.ios.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 @Stable
 actual class PeekabooCameraState(
     cameraMode: CameraMode,
+    internal var onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     internal var onCapture: (ByteArray?) -> Unit,
 ) {
     actual var isCameraReady: Boolean by mutableStateOf(false)
@@ -58,7 +59,10 @@ actual class PeekabooCameraState(
     }
 
     companion object {
-        fun saver(onCapture: (ByteArray?) -> Unit): Saver<PeekabooCameraState, Int> {
+        fun saver(
+            onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
+            onCapture: (ByteArray?) -> Unit,
+        ): Saver<PeekabooCameraState, Int> {
             return Saver(
                 save = {
                     it.cameraMode.id()
@@ -66,6 +70,7 @@ actual class PeekabooCameraState(
                 restore = {
                     PeekabooCameraState(
                         cameraMode = cameraModeFromId(it),
+                        onAnalyze = onAnalyze,
                         onCapture = onCapture,
                     )
                 },
@@ -77,11 +82,13 @@ actual class PeekabooCameraState(
 @Composable
 actual fun rememberPeekabooCameraState(
     initialCameraMode: CameraMode,
+    onAnalyze: ((frameTimeMs: Long, data: ByteArray) -> Unit)?,
     onCapture: (ByteArray?) -> Unit,
 ): PeekabooCameraState {
     return rememberSaveable(
-        saver = PeekabooCameraState.saver(onCapture),
-    ) { PeekabooCameraState(initialCameraMode, onCapture) }.apply {
+        saver = PeekabooCameraState.saver(onAnalyze, onCapture),
+    ) { PeekabooCameraState(initialCameraMode, onAnalyze, onCapture) }.apply {
+        this.onAnalyze = onAnalyze
         this.onCapture = onCapture
     }
 }

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -113,7 +113,7 @@ fun App() {
                                 }
                                 showCamera = false
                             },
-                            onAnalyze = { frameTimeMs, byteArray ->
+                            onFrame = { frameTimeMs, byteArray ->
                                 frames = frames + Pair(frameTimeMs, byteArray.toImageBitmap())
                                 if (frames.size > 15) {
                                     frames = frames.drop(1)

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -60,7 +60,7 @@ import com.preat.peekaboo.image.picker.toImageBitmap
 fun App() {
     val scope = rememberCoroutineScope()
     var images by remember { mutableStateOf(listOf<ImageBitmap>()) }
-    var frames by remember { mutableStateOf(listOf<Pair<Long, ImageBitmap>>()) }
+    var frames by remember { mutableStateOf(listOf<ImageBitmap>()) }
     val snackbarHostState = remember { SnackbarHostState() }
     var showCamera by rememberSaveable { mutableStateOf(false) }
     var showGallery by rememberSaveable { mutableStateOf(false) }
@@ -113,8 +113,8 @@ fun App() {
                                 }
                                 showCamera = false
                             },
-                            onFrame = { frameTimeMs, byteArray ->
-                                frames = frames + Pair(frameTimeMs, byteArray.toImageBitmap())
+                            onFrame = { frame ->
+                                frames = frames + frame.toImageBitmap()
                                 if (frames.size > 15) {
                                     frames = frames.drop(1)
                                 }
@@ -125,11 +125,11 @@ fun App() {
                                 .heightIn(min = 50.dp)
                                 .fillMaxWidth(),
                         ) {
-                            items(frames) { (frameTimeMs, image) ->
+                            items(frames) { image ->
                                 Box {
                                     Image(
                                         bitmap = image,
-                                        contentDescription = "Frame at $frameTimeMs ms",
+                                        contentDescription = "frame",
                                         contentScale = ContentScale.Crop,
                                         modifier = Modifier.size(50.dp),
                                     )

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -118,7 +118,7 @@ fun App() {
                                 if (frames.size > 15) {
                                     frames = frames.drop(1)
                                 }
-                            }
+                            },
                         )
                         LazyRow(
                             Modifier

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/App.kt
@@ -17,11 +17,14 @@ package com.preat.peekaboo.common
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -57,6 +60,7 @@ import com.preat.peekaboo.image.picker.toImageBitmap
 fun App() {
     val scope = rememberCoroutineScope()
     var images by remember { mutableStateOf(listOf<ImageBitmap>()) }
+    var frames by remember { mutableStateOf(listOf<Pair<Long, ImageBitmap>>()) }
     val snackbarHostState = remember { SnackbarHostState() }
     var showCamera by rememberSaveable { mutableStateOf(false) }
     var showGallery by rememberSaveable { mutableStateOf(false) }
@@ -101,7 +105,7 @@ fun App() {
                 when {
                     showCamera -> {
                         PeekabooCameraView(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.weight(1f),
                             onBack = { showCamera = false },
                             onCapture = { byteArray ->
                                 byteArray?.let {
@@ -109,7 +113,29 @@ fun App() {
                                 }
                                 showCamera = false
                             },
+                            onAnalyze = { frameTimeMs, byteArray ->
+                                frames = frames + Pair(frameTimeMs, byteArray.toImageBitmap())
+                                if (frames.size > 15) {
+                                    frames = frames.drop(1)
+                                }
+                            }
                         )
+                        LazyRow(
+                            Modifier
+                                .heightIn(min = 50.dp)
+                                .fillMaxWidth(),
+                        ) {
+                            items(frames) { (frameTimeMs, image) ->
+                                Box {
+                                    Image(
+                                        bitmap = image,
+                                        contentDescription = "Frame at $frameTimeMs ms",
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier.size(50.dp),
+                                    )
+                                }
+                            }
+                        }
                     }
                     showGallery -> {
                         PeekabooGalleryView(

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
@@ -45,9 +45,10 @@ import com.preat.peekaboo.ui.camera.rememberPeekabooCameraState
 internal fun PeekabooCameraView(
     modifier: Modifier = Modifier,
     onCapture: (ByteArray?) -> Unit,
+    onAnalyze: (Long, ByteArray) -> Unit,
     onBack: () -> Unit,
 ) {
-    val state = rememberPeekabooCameraState(onCapture = onCapture)
+    val state = rememberPeekabooCameraState(onCapture = onCapture, onAnalyze = onAnalyze)
     Box(modifier = modifier) {
         PeekabooCamera(
             state = state,

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
@@ -45,7 +45,7 @@ import com.preat.peekaboo.ui.camera.rememberPeekabooCameraState
 internal fun PeekabooCameraView(
     modifier: Modifier = Modifier,
     onCapture: (ByteArray?) -> Unit,
-    onFrame: (Long, ByteArray) -> Unit,
+    onFrame: (ByteArray) -> Unit,
     onBack: () -> Unit,
 ) {
     val state = rememberPeekabooCameraState(onCapture = onCapture, onFrame = onFrame)

--- a/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
+++ b/sample/common/src/commonMain/kotlin/com/preat/peekaboo/common/component/PeekabooCameraView.kt
@@ -45,10 +45,10 @@ import com.preat.peekaboo.ui.camera.rememberPeekabooCameraState
 internal fun PeekabooCameraView(
     modifier: Modifier = Modifier,
     onCapture: (ByteArray?) -> Unit,
-    onAnalyze: (Long, ByteArray) -> Unit,
+    onFrame: (Long, ByteArray) -> Unit,
     onBack: () -> Unit,
 ) {
-    val state = rememberPeekabooCameraState(onCapture = onCapture, onAnalyze = onAnalyze)
+    val state = rememberPeekabooCameraState(onCapture = onCapture, onFrame = onFrame)
     Box(modifier = modifier) {
         PeekabooCamera(
             state = state,

--- a/sample/ios/peekaboo/Info.plist
+++ b/sample/ios/peekaboo/Info.plist
@@ -4,5 +4,12 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+    <string>This app uses camera for capturing photos to demo the library</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>This app uses your photo library to demo the library</string>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
+    </dict>
 </dict>
 </plist>

--- a/sample/ios/peekaboo/Info.plist
+++ b/sample/ios/peekaboo/Info.plist
@@ -10,6 +10,5 @@
     <string>This app uses your photo library to demo the library</string>
     <key>CADisableMinimumFrameDurationOnPhone</key>
     <true/>
-    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
I am attempting to implement MLKit into a KMP application, and I need access to each frame from the camera to do Image analysis on it.

Peekaboo currently didn't have any way of exposing this, so this PR adds that feature.

You can pass `onFrame` to any of the peekaboo-ui functions to immediately receive frame data in the form of a `ByteArray` and the timestamp of the frame.

I have tested this on Android and iOS. However I couldn't get the sample in this repository to run on iOS. However I ported this library to my application and can confirm that frame updates work on iOS.